### PR TITLE
github 的表單欄位加上 bootstrap 的 prepend

### DIFF
--- a/app/views/account/edit.html.erb
+++ b/app/views/account/edit.html.erb
@@ -58,9 +58,11 @@
           <div class="clearfix">
               <%= f.label :github %>
               <div class="input">
-                <%= f.text_field :github, :class => "span3" %>
-                <span class="help-block">http://github.com/<span class="label success">:youname</span></span>
-            </div>
+                <div class="input-prepend">
+                  <span class="add-on">https://github.com/</span>
+                  <%= f.text_field :github, :class => "small", :placeholder => "username" %>
+                </div>
+              </div>
           </div>
           <div class="clearfix">
               <%= f.label :website %>


### PR DESCRIPTION
避免可能誤打 github 全址導致輸出的連結不正確，見 huacnlee/ruby-china#215